### PR TITLE
Add backwards compatibility with Neovim 0.9.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A scrollable `watch` alternative for Neovim.
 
 
 > [!IMPORTANT]
-> `watch.nvim` requires Neovim 0.10+!
+> `watch.nvim` requires `Neovim 0.9.5+`!
 
 `watch.nvim` is a simple plugin for live watching (i.e. continuously rerunning and
 checking the output of) a shell command in a Neovim buffer.
@@ -39,6 +39,7 @@ started Neovim.
 - [x] Pause watching when in the background
 - [x] Option to open in a configurable split window
 - [x] Option to watch for file changes
+- [x] Backwards compability with `Neovim 0.9.5`
 
 #### Planned:
 - [ ] ANSI color support

--- a/doc/watch.txt
+++ b/doc/watch.txt
@@ -2,7 +2,7 @@
 
 Author: Makaze <christopherslane.work@gmail.com>
 License: GPLv3.0
-Version: 0.3.0
+Version: 0.3.1
 
 ================================================================================
 INTRODUCTION                                                             *watch*
@@ -36,6 +36,7 @@ Features: ~
     [x] Pause watching when in the background
     [x] Option to open in a configurable split window
     [x] Option to watch for file changes
+    [x] Backwards compability with `Neovim 0.9.5`
 
 Planned: ~
     [ ] ANSI color support
@@ -184,11 +185,18 @@ watch.update({command}, {bufnr})                                *watch.update()*
 
     Parameters: ~
         {command}       (string)    Shell command to load to the buffer.
-        {bufnr}         (integer)   The buffer number to load to. Defaults to a
-                                    new buffer.
+        {bufnr}         (integer)   The buffer number to udpate.
 
     Return: ~
         {updater}       (function)  Steps to take upon rerunning {command}.
+
+watch.update_lines({lines}, {bufnr})                      *watch.update_lines()*
+    Sets the content of the watch buffer to {lines}, preserving the scroll
+    position. Used internally by |watch.update()|.
+
+    Parameters: ~
+        {lines}         (table)     The lines to replace into the buffer.
+        {bufnr}         (integer)   The buffer number to udpate.
 
 ================================================================================
 

--- a/lua/watch.lua
+++ b/lua/watch.lua
@@ -187,6 +187,17 @@ Watch.update = function(command, bufnr)
             return
         end
 
+        local W = Watch.watchers[command]
+        if W.file then
+            local update = file_updated(W.file, W.last_updated)
+
+            if update then
+                Watch.watchers[command].last_updated = update
+            else
+                return
+            end
+        end
+
         -- Execute your command and capture its output
 
         if vim.system then

--- a/lua/watch.lua
+++ b/lua/watch.lua
@@ -118,7 +118,7 @@ Watch.update = function(command, bufnr)
 
         -- Execute your command and capture its output
         -- Use vim.system for async
-        local code = vim.system(
+        local code = system(
             vim.split(command, " "),
             { text = true },
             function(out)

--- a/lua/watch.lua
+++ b/lua/watch.lua
@@ -16,9 +16,19 @@ local input = require("watch.input")
 --- @param bufnr integer The buffer number to check
 --- @return boolean visible
 local function is_visible(bufnr)
-    return vim.iter(A.nvim_list_wins()):any(function(win)
-        return A.nvim_win_get_buf(win) == bufnr
-    end)
+    if vim.iter then
+        return vim.iter(A.nvim_list_wins()):any(function(win)
+            return A.nvim_win_get_buf(win) == bufnr
+        end)
+    else
+        for _, win in ipairs(A.nvim_list_wins()) do
+            if A.nvim_win_get_buf(win) == bufnr then
+                return true
+            end
+        end
+    end
+
+    return false
 end
 
 --- Removes the current working directory from a buffer name.
@@ -37,10 +47,21 @@ end
 --- @param name string The buffer name to get.
 --- @return integer|nil bufnr
 local function get_buf_by_name(name)
-    return vim.iter(A.nvim_list_bufs()):find(function(b)
-        local bufname = collapse_bufname(A.nvim_buf_get_name(b))
-        return bufname == name
-    end)
+    if vim.iter then
+        return vim.iter(A.nvim_list_bufs()):find(function(b)
+            local bufname = collapse_bufname(A.nvim_buf_get_name(b))
+            return bufname == name
+        end)
+    else
+        for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+            local bufname = collapse_bufname(vim.api.nvim_buf_get_name(buf))
+            if bufname == name then
+                return buf
+            end
+        end
+    end
+
+    return nil
 end
 
 --- @type watch.Watcher[]

--- a/lua/watch.lua
+++ b/lua/watch.lua
@@ -4,8 +4,6 @@
 --- @field refresh_rate integer The refresh rate for the watcher in milliseconds.
 --- @field bufnr integer The buffer number attached to the watcher.
 --- @field timer function The timer object attached to the watcher.
---- @field file string|nil The filename to watch (if applicable).
---- @field last_updated integer The time since the file was last checked. Used when watching files.
 
 local Watch = {}
 
@@ -18,9 +16,19 @@ local input = require("watch.input")
 --- @param bufnr integer The buffer number to check
 --- @return boolean visible
 local function is_visible(bufnr)
-    return vim.iter(A.nvim_list_wins()):any(function(win)
-        return A.nvim_win_get_buf(win) == bufnr
-    end)
+    if vim.iter then
+        return vim.iter(A.nvim_list_wins()):any(function(win)
+            return A.nvim_win_get_buf(win) == bufnr
+        end)
+    else
+        for _, win in ipairs(A.nvim_list_wins()) do
+            if A.nvim_win_get_buf(win) == bufnr then
+                return true
+            end
+        end
+    end
+
+    return false
 end
 
 --- Removes the current working directory from a buffer name.
@@ -39,25 +47,21 @@ end
 --- @param name string The buffer name to get.
 --- @return integer|nil bufnr
 local function get_buf_by_name(name)
-    return vim.iter(A.nvim_list_bufs()):find(function(b)
-        local bufname = collapse_bufname(A.nvim_buf_get_name(b))
-        return bufname == name
-    end)
-end
-
---- Get the time a file was last updated, or `nil` if <= the result of last check.
----
---- @param path string The absolute file path.
---- @param last_check integer The unix timestamp to check against. Defaults to `0`.
---- @return integer|nil time
-local function file_updated(path, last_check)
-    last_check = last_check or 0
-    local stat = uv.fs_stat(path)
-    if stat and stat.type == "file" and stat.mtime.sec > last_check then
-        return stat.mtime.sec
+    if vim.iter then
+        return vim.iter(A.nvim_list_bufs()):find(function(b)
+            local bufname = collapse_bufname(A.nvim_buf_get_name(b))
+            return bufname == name
+        end)
     else
-        return nil
+        for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+            local bufname = collapse_bufname(vim.api.nvim_buf_get_name(buf))
+            if bufname == name then
+                return buf
+            end
+        end
     end
+
+    return nil
 end
 
 --- @type watch.Watcher[]
@@ -65,20 +69,10 @@ end
 --- Global list of watchers and associated data.
 Watch.watchers = {}
 
---- @class watch.SplitConfig
----
---- @field enabled boolean Whether to open the watch in a new split. Defaults to `false`.
---- @field position '"above"'|'"below"'|'"right"'|'"left'" Where to place the split (above|below|right|left). Defaults to `below`.
---- @field size integer|nil The size of the split in rows (or columns if position is right or left). Defaults to `nil`.
---- @field focus boolean Whether to focus on the newly created split watcher. Defaults to `true`.
----
---- Configuration for watch.nvim.
-
 --- @class watch.Config
 ---
 --- @field refresh_rate integer The default refresh rate for a new watcher in milliseconds. Defaults to `500`.
 --- @field close_on_stop boolean Whether to automatically delete the buffer when stopping a watcher. Defaults to `false`.
---- @field split watch.SplitConfig Configuration options for opening the watcher in a split.
 ---
 --- Configuration for watch.nvim.
 
@@ -86,35 +80,19 @@ Watch.watchers = {}
 Watch.config = {
     refresh_rate = 500,
     close_on_stop = false,
-    split = {
-        enabled = false,
-        position = "below",
-        size = nil,
-        focus = true,
-    },
 }
-
---- @class watch.SplitConfigOverride
----
---- @field enabled boolean Whether to open the watch in a new split. Defaults to `false`.
---- @field position? '"above"'|'"below"'|'"right"'|'"left'" Where to place the split (above|below|right|left). Defaults to `below`.
---- @field size? integer|nil The size of the split in rows (or columns if position is right or left). Defaults to `nil`.
---- @field focus? boolean Whether to focus on the newly created split watcher. Defaults to `true`.
----
---- Configuration for watch.nvim.
 
 --- @class watch.ConfigOverride
 ---
---- @field refresh_rate? integer The default refresh rate for a new watcher in milliseconds. Defaults to `500`.
---- @field close_on_stop? boolean Whether to automatically delete the buffer when stopping a watcher. Defaults to `false`.
---- @field split? watch.SplitConfigOverride Configuration options for opening the watcher in a split.
+--- @field refresh_rate integer? The default refresh rate for a new watcher in milliseconds. Defaults to `500`.
+--- @field close_on_stop boolean? Whether to automatically delete the buffer when stopping a watcher. Defaults to `false`.
 ---
 --- Configuration overrides for watch.nvim.
 
 --- Changes configuration options. See `:help watch-config`.
 --- You do not have to call this function unless you want to change anything!
 ---
---- @param opts? watch.ConfigOverride
+--- @param opts watch.ConfigOverride?
 Watch.setup = function(opts)
     -- Do nothing if nothing given
     if not opts or not next(opts) then
@@ -124,7 +102,30 @@ Watch.setup = function(opts)
         vim.tbl_deep_extend("force", Watch.config, vim.F.if_nil(opts, {}))
 end
 
---- Replaces a buffer's contents with a shell command while preserving the cursor.
+--- Replaces the lines in a buffer while preserving the cursor.
+---
+--- @param lines table The lines to replace into the buffer.
+--- @param bufnr integer The buffer number to update.
+Watch.update_lines = function(lines, bufnr)
+    -- Save current cursor position
+    local save_cursor = A.nvim_win_get_cursor(0)
+
+    -- Strip ANSI color codes from the output
+    local stripped_output = {}
+    for _, line in ipairs(lines) do
+        local stripped_line = line:gsub("\27%[[%d;]*[mK]", "") -- Remove ANSI escape sequences
+        table.insert(stripped_output, stripped_line)
+        -- table.insert(stripped_output, line)
+    end
+
+    -- Clear the buffer and insert the stripped output
+    A.nvim_buf_set_lines(bufnr, 0, -1, false, stripped_output)
+
+    -- Restore cursor position
+    A.nvim_win_set_cursor(0, save_cursor)
+end
+
+--- Returns a function that updates the buffer's contents and preserves the cursor.
 ---
 --- @param command string Shell command.
 --- @param bufnr integer The buffer number to update.
@@ -136,68 +137,90 @@ Watch.update = function(command, bufnr)
             return
         end
 
-        local W = Watch.watchers[command]
-        if W.file then
-            local update = file_updated(W.file, W.last_updated)
-
-            if update then
-                Watch.watchers[command].last_updated = update
-            else
-                return
-            end
-        end
-
         -- Execute your command and capture its output
-        -- Use vim.system for async
-        local code = vim.system(
-            vim.split(command, " "),
-            { text = true },
-            function(out)
-                -- Need vim.schedule to use most actions inside of vim loop
-                vim.schedule(function()
-                    -- Handle error
-                    if out.code ~= 0 then
-                        if Watch.watchers[command] then
-                            Watch.kill(command)
-                            vim.notify(
-                                "[watch] ! Stopping: " .. out.stderr,
-                                vim.log.levels.ERROR
-                            )
+
+        if vim.system then
+            -- Use vim.system for async
+            local code = vim.system(
+                vim.split(command, " "),
+                { text = true },
+                function(out)
+                    -- Need vim.schedule to use most actions inside of vim loop
+                    vim.schedule(function()
+                        -- Handle error
+                        if out.code ~= 0 then
+                            if Watch.watchers[command] then
+                                Watch.kill(command)
+                                vim.notify(
+                                    "[watch] ! Stopping: " .. out.stderr,
+                                    vim.log.levels.ERROR
+                                )
+                            end
+                            return
                         end
-                        return
-                    end
 
-                    -- Save current cursor position
-                    local save_cursor = A.nvim_win_get_cursor(0)
+                        Watch.update_lines(vim.split(out.stdout, "\n"), bufnr)
+                    end)
+                end
+            )
+        else
+            -- Use vim.fn.jobstart for compatibility
+            local args = vim.split(command, " ")
+            local cmd = table.remove(args, 1)
 
-                    local output = vim.split(out.stdout, "\n")
+            local stdout = uv.new_pipe(false)
+            local stderr = uv.new_pipe(false)
+            local results = {}
+            local handle = nil
 
-                    -- Strip ANSI color codes from the output
-                    local stripped_output = {}
-                    for _, line in ipairs(output) do
-                        local stripped_line = line:gsub("\27%[[%d;]*[mK]", "") -- Remove ANSI escape sequences
-                        table.insert(stripped_output, stripped_line)
-                        -- table.insert(stripped_output, line)
-                    end
+            handle = uv.spawn(
+                cmd,
+                {
+                    args = args,
+                    stdio = { nil, stdout, stderr },
+                },
+                vim.schedule_wrap(function()
+                    stdout:read_stop()
+                    stderr:read_stop()
+                    stdout:close()
+                    stderr:close()
+                    handle:close()
 
-                    -- Clear the buffer and insert the stripped output
-                    A.nvim_buf_set_lines(bufnr, 0, -1, false, stripped_output)
-
-                    -- Restore cursor position
-                    A.nvim_win_set_cursor(0, save_cursor)
+                    Watch.update_lines(results, bufnr)
                 end)
+            )
+
+            local function onread(err, data)
+                if err then
+                    if Watch.watchers[command] then
+                        Watch.kill(command)
+                        vim.notify(
+                            "[watch] ! Stopping: " .. err,
+                            vim.log.levels.ERROR
+                        )
+                    end
+                    return
+                end
+                if data then
+                    local vals = vim.split(data, "\n")
+                    for _, d in pairs(vals) do
+                        table.insert(results, d)
+                    end
+                end
             end
-        )
+
+            uv.read_start(stdout, onread)
+            uv.read_start(stderr, onread)
+        end
     end
 end
 
 --- Starts continually reloading a buffer's contents with a shell command. If the command is aleady being watched, then opens that buffer in the current window.
 ---
---- @param command string Shell command to watch. If `file` is given, then `%s` will expand to the filename.
---- @param refresh_rate? integer Time between reloads in milliseconds. Defaults to `watch.config.refresh_rate`. If `file` is provided, then it is increased to a minimum of 1000 ms.
---- @param bufnr? integer Buffer number to update. Defaults to a new buffer.
---- @param file? string The absolute path of the file to watch. Defaults to `nil`.
-Watch.start = function(command, refresh_rate, bufnr, file)
+--- @param command string Shell command.
+--- @param refresh_rate integer? Time between reloads in milliseconds. Defaults to `watch.config.refresh_rate`.
+--- @param bufnr integer? Buffer number to update. Defaults to a new buffer.
+Watch.start = function(command, refresh_rate, bufnr)
     -- Check if command is nil
     if not command or not string.len(command) then
         vim.notify("[watch] Error: Empty command passed", vim.log.levels.ERROR)
@@ -211,11 +234,6 @@ Watch.start = function(command, refresh_rate, bufnr, file)
             vim.log.levels.ERROR
         )
         return
-    end
-
-    -- Expand %s to the filename
-    if file then
-        command = string.gsub(command, "%%s", file)
     end
 
     -- Open the buffer if already running
@@ -237,32 +255,6 @@ Watch.start = function(command, refresh_rate, bufnr, file)
         refresh_rate = Watch.config.refresh_rate
     end
 
-    -- Minimum 1000 ms if file check
-    if file and refresh_rate < 1000 then
-        vim.notify(
-            "[watch] File watchers require refresh_rate >= 1000. Increasing to 1000 ms."
-        )
-        refresh_rate = 1000
-    end
-
-    -- Create a split based on configurations
-    local split = Watch.config.split or {}
-    if split and split.enabled then
-        local position = split.position
-        local size = split.size or ""
-
-        if position == "above" then
-            A.nvim_command("split | wincmd k | resize " .. size)
-        elseif position == "right" then
-            A.nvim_command(size .. "vsplit")
-        elseif position == "left" then
-            A.nvim_command("vsplit | wincmd h | vertical resize " .. size)
-        else
-            -- Must be "below" by default
-            A.nvim_command(size .. "split")
-        end
-    end
-
     -- Get existing bufnr if bufname already exists
     bufnr = get_buf_by_name(command) or bufnr
 
@@ -275,13 +267,6 @@ Watch.start = function(command, refresh_rate, bufnr, file)
 
     -- Always set as current buffer when starting
     A.nvim_win_set_buf(0, bufnr)
-
-    -- Unfocus the window if set to false
-    if split and split.enabled then
-        if not split.focus then
-            A.nvim_command("wincmd p")
-        end
-    end
 
     -- Set up a timer to run the function every refresh_rate
     local timer = uv.new_timer()
@@ -297,8 +282,6 @@ Watch.start = function(command, refresh_rate, bufnr, file)
         bufnr = bufnr,
         refresh_rate = refresh_rate,
         timer = timer,
-        file = file,
-        last_updated = 0,
     }
 
     Watch.watchers[command] = watcher
@@ -317,7 +300,7 @@ end
 ---
 --- `WARNING:` If `watch.config.close_on_stop` is set to `true`, then affected buffers will also be deleted.
 ---
---- @param event? string|table The shell command to stop. If string, then uses the string. If table, then uses `event.file`.
+--- @param event string|table? The command name to stop. If string, then uses the string. If table, then uses `event.file`.
 Watch.stop = function(event)
     -- Get the current buffer if it is a watcher
     local bufname = nil

--- a/lua/watch.lua
+++ b/lua/watch.lua
@@ -114,6 +114,8 @@ Watch.update = function(command, bufnr)
             return
         end
 
+        local system = vim.system or vim.fn.system
+
         -- Execute your command and capture its output
         -- Use vim.system for async
         local code = vim.system(


### PR DESCRIPTION
Like it says on the tin.

- Uses ipairs and pairs to avoid vim.iter when not available
- Uses vim.loop.spawn when vim.system is not available